### PR TITLE
global: inveniosoftware.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ after_success:
 deploy:
   provider: npm
   skip_cleanup: true
-  email: info@invenio-software.org
+  email: info@inveniosoftware.org
   api_key:
     secure: mVjw6DB1kmDXjaJy5KfL6ztRHll0WTecU2DuJyVadx6E00snROlx9TDE+OkIKNbh4aJBfok2JvtiVzh5J11X2hQ0mJs/oKkv49Tbqf44CGpmm1sRSYdnGQZpkqSLvLeMi/R2V81vrC3Cf9+08wJCRagQR5Pm0/h9vmP8DJFwoD1JfB7K8coo8KO1M9npNxA/d6jYe1Z6seT7bKVrnRVlJZFpPRPwoYg1cO7j1ZZ1ovpkqYLHSpHAC8RdJBplx6/gBtdcfvUAb+0vlKkRD47beuydzPPSy7x3iK9sr6+8RpAKNL5m7avCh0sYy/VG0G0YIvCwAshA+PHHrifBWuamgQdadKtStSL3rc/DvNm+q2q6EUk1ACWA9o0SVPqMKjjLoyv9eHUbUV6amZWU4LrEZ3tZb2C0QCYbAbh5rLEn107cFTqQ+S45nui8XBWFTo0H7tfgKiNZ/mSVyhgLTYDdr8xXak3kvnXzCjHop/nSIFx+dnmiw9YHq6QQ58l//MYS90zHjSGBZASKyGb6h1P+5ZILcNdGYNTXp98faC0DXrcJgVcq8qLcHhyPkrG0segiA1o4y/u4R4tmJFrifjPwNt/KTWe9411gI6NxWatDB4AZkD2CdXEUScWGy6g7AcMXJJDYHDhEu+lsUEjzDeUwZQ4W4YawzGOwpJwJihU1Y70=
   on:

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -29,8 +29,8 @@ Documentation
 Happy hacking and thanks for flying Generator-Invenio-JS-Module.
 
 | Invenio Development Team
-|   Email: info@invenio-software.org
+|   Email: info@inveniosoftware.org
 |   IRC: #invenio on irc.freenode.net
 |   Twitter: http://twitter.com/inveniosoftware
 |   GitHub: https://github.com/inveniosoftware/invenio-search-ui
-|   URL: http://invenio-software.org
+|   URL: http://inveniosoftware.org

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -66,7 +66,7 @@ module.exports = yeoman.generators.Base.extend({
         type: 'input',
         name: 'author_email',
         message: 'Your project author\'s email',
-        default: 'info@invenio-software.org'
+        default: 'info@inveniosoftware.org'
       },
       {
         type: 'input',

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Invenio generator",
   "author": {
     "name": "CERN",
-    "email": "info@invenio-software.org"
+    "email": "info@inveniosoftware.org"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Changes `invenio-software.org` to `inveniosoftware.org` to use the
  same dashless canonical ID everywhere (GitHub, Twitter, Web).

Signed-off-by: Tibor Simko tibor.simko@cern.ch
